### PR TITLE
examples: use .limits(Axes::X, ...), not .xlimits()

### DIFF
--- a/plt/examples/detailed.rs
+++ b/plt/examples/detailed.rs
@@ -25,8 +25,8 @@ fn main() {
         })
         .xlabel("X [arbitrary units]")
         .ylabel("Y [arbitrary units]")
-        .xlimits(Limits::Manual { min: 0.0, max: 10.0 })
-        .ylimits(Limits::Manual { min: 0.0, max: 1e3 })
+        .limits(Axes::X, Limits::Manual { min: 0.0, max: 10.0 })
+        .limits(Axes::Y, Limits::Manual { min: 0.0, max: 1e3 })
         .standard_grid()
         .build();
 

--- a/plt/examples/grid.rs
+++ b/plt/examples/grid.rs
@@ -57,8 +57,8 @@ fn main() {
             font_size: 16.0,
             ..Default::default()
         })
-        .xlimits(Limits::Manual { min: -6.0, max: 6.0 })
-        .ylimits(Limits::Manual { min: 0.0, max: 500.0 })
+        .limits(Axes::X, Limits::Manual { min: -6.0, max: 6.0 })
+        .limits(Axes::Y, Limits::Manual { min: 0.0, max: 500.0 })
         .minor_tick_marks(Axes::BothPrimary, TickSpacing::Count(1))
         .major_tick_marks(Axes::BothSecondary, TickSpacing::None)
         .minor_tick_marks(Axes::BothSecondary, TickSpacing::None)
@@ -77,8 +77,8 @@ fn main() {
             font_size: 16.0,
             ..Default::default()
         })
-        .xlimits(Limits::Manual { min: -6.0, max: 6.0 })
-        .ylimits(Limits::Manual { min: 0.0, max: 500.0 })
+        .limits(Axes::X, Limits::Manual { min: -6.0, max: 6.0 })
+        .limits(Axes::Y, Limits::Manual { min: 0.0, max: 500.0 })
         .minor_tick_marks(Axes::BothPrimary, TickSpacing::Count(1))
         .major_tick_marks(Axes::BothSecondary, TickSpacing::None)
         .minor_tick_marks(Axes::BothSecondary, TickSpacing::None)

--- a/plt/examples/step.rs
+++ b/plt/examples/step.rs
@@ -13,8 +13,8 @@ fn main() {
         })
         .xlabel("X [arbitrary units]")
         .ylabel("Y [arbitrary units]")
-        .xlimits(Limits::Manual { min: 0.0, max: 50.0 })
-        .ylimits(Limits::Manual { min: 0.0, max: 5.0 })
+        .limits(Axes::X, Limits::Manual { min: 0.0, max: 50.0 })
+        .limits(Axes::Y, Limits::Manual { min: 0.0, max: 5.0 })
         .major_tick_marks(Axes::BothX, TickSpacing::Count(6))
         .standard_grid()
         .build();


### PR DESCRIPTION
This gets the examples to compile with current code.